### PR TITLE
Develop

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,4 @@
 {
   "name": "GlueApp",
-  "displayName": "GlueApp"
+  "displayName": "Glue"
 }

--- a/ios/GlueApp.xcodeproj/project.pbxproj
+++ b/ios/GlueApp.xcodeproj/project.pbxproj
@@ -341,7 +341,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.zuraft.glue;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sadajo.glue;
 				PRODUCT_NAME = GlueApp;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -370,7 +370,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.zuraft.glue;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sadajo.glue;
 				PRODUCT_NAME = GlueApp;
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/ios/GlueApp/Info2.plist
+++ b/ios/GlueApp/Info2.plist
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Glue</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakaobde0f16bb089ff8cadefd325d5fcc49a</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>KAKAO_APP_KEY</key>
+	<string>bde0f16bb089ff8cadefd325d5fcc49a</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>storykompassauth</string>
+		<string>kakaolink</string>
+	</array>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>이 앱은 프로필 사진을 촬영하기 위해 카메라 접근 권한이 필요합니다.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string></string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>이 앱은 사진을 저장하기 위해 사진 라이브러리 접근 권한이 필요합니다.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>이 앱은 프로필 사진을 선택하기 위해 사진 라이브러리 접근 권한이 필요합니다.</string>
+	<key>UIAppFonts</key>
+	<array>
+		<string>Pretendard-Black.otf</string>
+		<string>Pretendard-Bold.otf</string>
+		<string>Pretendard-ExtraBold.otf</string>
+		<string>Pretendard-ExtraLight.otf</string>
+		<string>Pretendard-Light.otf</string>
+		<string>Pretendard-Medium.otf</string>
+		<string>Pretendard-Regular.otf</string>
+		<string>Pretendard-SemiBold.otf</string>
+		<string>Pretendard-Thin.otf</string>
+	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
+	<key>UIStatusBarHidden</key>
+	<false/>
+	<key>UIRequiresFullScreen</key>
+	<false/>
+</dict>
+</plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@react-navigation/native": "^6.1.9",
         "@react-navigation/native-stack": "^6.9.22",
         "@react-navigation/stack": "^6.3.20",
+        "@stomp/stompjs": "^7.1.1",
         "@tanstack/react-query": "^5.22.2",
         "axios": "^1.9.0",
         "i18next": "^25.2.0",
@@ -42,7 +43,8 @@
         "react-native-svg": "^15.11.2",
         "react-native-toast-message": "^2.2.0",
         "react-native-webview": "^13.13.5",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "ws": "^8.18.2"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -60,6 +62,7 @@
         "@types/react": "^19.0.0",
         "@types/react-test-renderer": "^19.0.0",
         "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.18.1",
         "babel-plugin-module-resolver": "^5.0.2",
         "eslint": "^8.19.0",
         "jest": "^29.6.3",
@@ -3687,6 +3690,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@react-native-community/cli-server-api/node_modules/ws": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "node_modules/@react-native-community/cli-tools": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-15.0.1.tgz",
@@ -4113,6 +4126,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@react-native/dev-middleware/node_modules/ws": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "node_modules/@react-native/eslint-config": {
       "version": "0.78.2",
       "resolved": "https://registry.npmjs.org/@react-native/eslint-config/-/eslint-config-0.78.2.tgz",
@@ -4394,6 +4416,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.1.1.tgz",
+      "integrity": "sha512-chcDs6YkAnKp1FqzwhGvh3i7v0+/ytzqWdKYw6XzINEKAzke/iD00dNgFPWSZEqktHOK+C1gSzXhLkLbARIaZw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -4846,6 +4874,16 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -13072,6 +13110,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native/node_modules/ws": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -15227,12 +15274,24 @@
       }
     },
     "node_modules/ws": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
       "license": "MIT",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.22",
     "@react-navigation/stack": "^6.3.20",
+    "@stomp/stompjs": "^7.1.1",
     "@tanstack/react-query": "^5.22.2",
     "axios": "^1.9.0",
     "i18next": "^25.2.0",
@@ -59,7 +60,8 @@
     "react-native-svg": "^15.11.2",
     "react-native-toast-message": "^2.2.0",
     "react-native-webview": "^13.13.5",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "ws": "^8.18.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -77,6 +79,7 @@
     "@types/react": "^19.0.0",
     "@types/react-test-renderer": "^19.0.0",
     "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.18.1",
     "babel-plugin-module-resolver": "^5.0.2",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",

--- a/src/app/providers/navigation/index.tsx
+++ b/src/app/providers/navigation/index.tsx
@@ -19,7 +19,7 @@ import {
 import {GroupStackParamList} from '@features/Group/model/types';
 
 // 채팅 화면 컴포넌트 임포트
-import {ChatListScreen, ChatRoomScreen} from '@features/Chat';
+import {ChatRoomListScreen, ChatRoomScreen} from '@features/Chat';
 
 // 프로필 화면 컴포넌트 임포트
 import {
@@ -107,16 +107,20 @@ const BoardNavigator = () => (
 // 메시지 스택 네비게이터
 const MessagesNavigator = () => (
   <MessagesStack.Navigator screenOptions={commonHeaderOptions}>
-    <MessagesStack.Screen
-      name="MessagesList"
-      component={ChatListScreen}
-      options={{headerShown: false}}
-    />
-    <MessagesStack.Screen
-      name="ChatRoom"
-      component={ChatRoomScreen}
-      options={{headerShown: false}}
-    />
+    <MessagesStack.Screen name="MessagesList" options={{headerShown: false}}>
+      {props => (
+        <ChatRoomListScreen
+          {...props}
+          chatRooms={[]} // 빈 배열로 초기화, 실제 데이터는 ChatRoomListScreen 내부에서 API로 로드
+          onChatRoomPress={roomId => {
+            props.navigation.navigate('ChatRoom', {roomId});
+          }}
+          onDmChatRoomPress={dmRoomId => {
+            props.navigation.navigate('ChatRoom', {dmChatRoomId: dmRoomId});
+          }}
+        />
+      )}
+    </MessagesStack.Screen>
   </MessagesStack.Navigator>
 );
 
@@ -353,6 +357,11 @@ export const AppNavigator = () => {
       <GroupStack.Screen
         name="Guestbook"
         component={GuestbookScreen}
+        options={{headerShown: false}}
+      />
+      <MessagesStack.Screen
+        name="ChatRoom"
+        component={ChatRoomScreen}
         options={{headerShown: false}}
       />
     </RootStack.Navigator>

--- a/src/features/Chat/api/api.ts
+++ b/src/features/Chat/api/api.ts
@@ -21,6 +21,70 @@ export interface DmChatRoom {
   hasUnreadMessages: boolean;
 }
 
+// 사용자 요약 정보 타입
+export interface UserSummary {
+  userId: number;
+  userName: string;
+  profileImageUrl: string | null;
+}
+
+// 호스트 정보가 포함된 사용자 요약 타입
+export interface UserSummaryWithHostInfo extends UserSummary {
+  isHost: boolean;
+}
+
+// DM 메시지 응답 타입
+export interface DmMessageResponse {
+  dmMessageId: number;
+  dmChatRoomId: number;
+  sender: UserSummary;
+  content: string;
+  isRead: number; // 0: 읽지 않음, 1: 읽음
+  createdAt: string;
+}
+
+// 실제 API 응답에서 사용되는 참가자 타입
+export interface DmChatRoomParticipant {
+  isHost: boolean;
+  user: {
+    userId: number;
+    userNickname: string;
+    profileImageUrl: string | null;
+  };
+}
+
+// 실제 DM 채팅방 상세 정보 응답 타입 (실제 API 응답 구조)
+export interface ActualDmChatRoomDetailResponse {
+  dmChatRoomId: number;
+  meetingId: number;
+  participants: DmChatRoomParticipant[];
+  isPushNotificationOn?: number;
+  invitationStatus?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// DM 채팅방 상세 정보 응답 타입
+export interface DmChatRoomDetailResponse {
+  dmChatRoomId: number;
+  meetingId: number;
+  participants: UserSummaryWithHostInfo[];
+  isPushNotificationOn?: number;
+  invitationStatus?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// DM 메시지 전송 요청 타입
+export interface DmMessageSendRequest {
+  content: string;
+}
+
+// DM 메시지 읽음 요청 타입
+export interface DmMessageReadRequest {
+  receiverId: number;
+}
+
 /**
  * 내가 호스트인 DM 채팅방 목록을 가져오는 API 함수
  * @returns API 응답 데이터
@@ -135,6 +199,211 @@ export const getParticipatedDmRooms = async (): Promise<
       // 기본 에러 메시지
       const errorMessage =
         error.response.data?.message || 'DM 채팅방 목록 조회에 실패했습니다.';
+      throw new Error(errorMessage);
+    }
+
+    // 기타 에러
+    throw error;
+  }
+};
+
+/**
+ * DM 채팅방 상세 정보를 가져오는 API 함수
+ * @param dmChatRoomId 채팅방 ID
+ * @returns API 응답 데이터
+ */
+export const getDmChatRoomDetail = async (
+  dmChatRoomId: number,
+): Promise<ApiResponse<ActualDmChatRoomDetailResponse>> => {
+  const endpoint = `/api/dm/rooms/${dmChatRoomId}`;
+  const url = `${config.API_URL}${endpoint}`;
+  console.log(`[API 요청] DM 채팅방 상세 정보 조회: ${url}`);
+
+  try {
+    // JWT 토큰 가져오기
+    const token = await secureStorage.getToken();
+    if (!token) {
+      throw new Error('인증 토큰이 없습니다. 로그인이 필요합니다.');
+    }
+
+    // API 요청 보내기
+    const response = await apiClient.get(endpoint, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    console.log('DM 채팅방 상세 정보 응답:', response.data);
+
+    // 서버 응답 처리
+    return {
+      data: response.data,
+      success: true,
+      message: '',
+    };
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      // 네트워크 오류
+      if (!error.response) {
+        throw new Error('네트워크 연결에 문제가 있습니다.');
+      }
+
+      // HTTP 상태 코드별 에러 처리
+      const status = error.response.status;
+      if (status === 401) {
+        throw new Error('인증이 필요합니다. 다시 로그인해주세요.');
+      } else if (status === 403) {
+        throw new Error('채팅방 정보를 조회할 권한이 없습니다.');
+      } else if (status === 404) {
+        throw new Error('존재하지 않는 채팅방입니다.');
+      } else if (status >= 500) {
+        throw new Error('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+
+      // 기본 에러 메시지
+      const errorMessage =
+        error.response.data?.message ||
+        'DM 채팅방 상세 정보 조회에 실패했습니다.';
+      throw new Error(errorMessage);
+    }
+
+    // 기타 에러
+    throw error;
+  }
+};
+
+/**
+ * DM 메시지 목록을 가져오고 읽음 처리하는 API 함수
+ * @param dmChatRoomId 채팅방 ID
+ * @returns API 응답 데이터
+ */
+export const getDmMessages = async (
+  dmChatRoomId: number,
+): Promise<ApiResponse<DmMessageResponse[]>> => {
+  const endpoint = `/api/dm/${dmChatRoomId}/all-messages`;
+  const url = `${config.API_URL}${endpoint}`;
+  console.log(`[API 요청] DM 메시지 목록 조회: ${url}`);
+
+  try {
+    // JWT 토큰 가져오기
+    const token = await secureStorage.getToken();
+    if (!token) {
+      throw new Error('인증 토큰이 없습니다. 로그인이 필요합니다.');
+    }
+
+    // API 요청 보내기 (PUT 메서드 사용)
+    const response = await apiClient.put(
+      endpoint,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    console.log('DM 메시지 목록 응답:', response.data);
+
+    // 서버 응답 처리
+    return {
+      data: response.data,
+      success: true,
+      message: '',
+    };
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      // 네트워크 오류
+      if (!error.response) {
+        throw new Error('네트워크 연결에 문제가 있습니다.');
+      }
+
+      // HTTP 상태 코드별 에러 처리
+      const status = error.response.status;
+      if (status === 401) {
+        throw new Error('인증이 필요합니다. 다시 로그인해주세요.');
+      } else if (status === 403) {
+        throw new Error('메시지를 조회할 권한이 없습니다.');
+      } else if (status === 404) {
+        throw new Error('존재하지 않는 채팅방입니다.');
+      } else if (status >= 500) {
+        throw new Error('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+
+      // 기본 에러 메시지
+      const errorMessage =
+        error.response.data?.message || 'DM 메시지 조회에 실패했습니다.';
+      throw new Error(errorMessage);
+    }
+
+    // 기타 에러
+    throw error;
+  }
+};
+
+/**
+ * DM 메시지를 전송하는 API 함수
+ * @param dmChatRoomId 채팅방 ID
+ * @param content 메시지 내용
+ * @returns API 응답 데이터
+ */
+export const sendDmMessage = async (
+  dmChatRoomId: number,
+  content: string,
+): Promise<ApiResponse<DmMessageResponse>> => {
+  const endpoint = `/api/dm/${dmChatRoomId}/send-message`;
+  const url = `${config.API_URL}${endpoint}`;
+  console.log(`[API 요청] DM 메시지 전송: ${url}`, {content});
+
+  try {
+    // JWT 토큰 가져오기
+    const token = await secureStorage.getToken();
+    if (!token) {
+      throw new Error('인증 토큰이 없습니다. 로그인이 필요합니다.');
+    }
+
+    // API 요청 보내기
+    const response = await apiClient.post(
+      endpoint,
+      {content},
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    console.log('DM 메시지 전송 응답:', response.data);
+
+    // 서버 응답 처리
+    return {
+      data: response.data,
+      success: true,
+      message: '',
+    };
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      // 네트워크 오류
+      if (!error.response) {
+        throw new Error('네트워크 연결에 문제가 있습니다.');
+      }
+
+      // HTTP 상태 코드별 에러 처리
+      const status = error.response.status;
+      if (status === 400) {
+        throw new Error('잘못된 요청입니다. 메시지 내용을 확인해주세요.');
+      } else if (status === 401) {
+        throw new Error('인증이 필요합니다. 다시 로그인해주세요.');
+      } else if (status === 403) {
+        throw new Error('메시지를 전송할 권한이 없습니다.');
+      } else if (status === 404) {
+        throw new Error('존재하지 않는 채팅방입니다.');
+      } else if (status >= 500) {
+        throw new Error('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+
+      // 기본 에러 메시지
+      const errorMessage =
+        error.response.data?.message || 'DM 메시지 전송에 실패했습니다.';
       throw new Error(errorMessage);
     }
 

--- a/src/features/Chat/api/hooks.ts
+++ b/src/features/Chat/api/hooks.ts
@@ -1,5 +1,14 @@
-import {useApiQuery} from '@/shared/lib/api/hooks';
-import {DmChatRoom, getHostedDmRooms, getParticipatedDmRooms} from './api';
+import {useApiQuery, useApiMutation} from '@/shared/lib/api/hooks';
+import {
+  DmChatRoom,
+  getHostedDmRooms,
+  getParticipatedDmRooms,
+  ActualDmChatRoomDetailResponse,
+  getDmChatRoomDetail,
+  DmMessageResponse,
+  getDmMessages,
+  sendDmMessage,
+} from './api';
 
 /**
  * 내가 호스트인 DM 채팅방 목록을 가져오는 React Query 훅
@@ -29,6 +38,64 @@ export const useParticipatedDmRooms = () => {
       staleTime: 1000 * 60 * 5, // 5분 동안 데이터 신선한 상태 유지
       refetchOnWindowFocus: true, // 창이 포커스될 때 다시 가져오기
       retry: 1, // 실패 시 1번 재시도
+    },
+  );
+};
+
+/**
+ * DM 채팅방 상세 정보를 가져오는 React Query 훅
+ * @param dmChatRoomId 채팅방 ID
+ * @returns useQuery 훅의 반환값
+ */
+export const useDmChatRoomDetail = (dmChatRoomId: number) => {
+  return useApiQuery<ActualDmChatRoomDetailResponse>(
+    ['dmChatRoomDetail', dmChatRoomId.toString()],
+    () => getDmChatRoomDetail(dmChatRoomId),
+    {
+      staleTime: 1000 * 60 * 2, // 2분 동안 데이터 신선한 상태 유지
+      refetchOnWindowFocus: false, // 창 포커스 시 다시 가져오기 안함
+      retry: 1, // 실패 시 1번 재시도
+      enabled: dmChatRoomId !== -1 && dmChatRoomId > 0, // 유효한 dmChatRoomId일 때만 쿼리 실행
+    },
+  );
+};
+
+/**
+ * DM 메시지 목록을 가져오는 React Query 훅
+ * @param dmChatRoomId 채팅방 ID
+ * @returns useQuery 훅의 반환값
+ */
+export const useDmMessages = (dmChatRoomId: number) => {
+  return useApiQuery<DmMessageResponse[]>(
+    ['dmMessages', dmChatRoomId.toString()],
+    () => getDmMessages(dmChatRoomId),
+    {
+      staleTime: 0, // 메시지는 항상 최신 상태로 유지
+      refetchOnWindowFocus: true, // 창이 포커스될 때 다시 가져오기
+      retry: 1, // 실패 시 1번 재시도
+      enabled: dmChatRoomId !== -1 && dmChatRoomId > 0, // 유효한 dmChatRoomId일 때만 쿼리 실행
+    },
+  );
+};
+
+/**
+ * DM 메시지 전송을 위한 React Query 뮤테이션 훅
+ * @returns useMutation 훅의 반환값
+ */
+export const useSendDmMessage = () => {
+  return useApiMutation<
+    DmMessageResponse,
+    {dmChatRoomId: number; content: string}
+  >(
+    'sendDmMessage',
+    ({dmChatRoomId, content}) => sendDmMessage(dmChatRoomId, content),
+    {
+      onSuccess: response => {
+        console.log('DM 메시지 전송 성공:', response.data);
+      },
+      onError: error => {
+        console.error('DM 메시지 전송 실패:', error.message);
+      },
     },
   );
 };

--- a/src/features/Chat/components/ChatRoomInfo/index.tsx
+++ b/src/features/Chat/components/ChatRoomInfo/index.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import {useTranslation} from 'react-i18next';
 import {Text} from '../../../../shared/ui/typography/Text';
-import {Bell, Exit, Mail, Mine, Pen} from '@shared/assets/images';
+import {Bell, Exit, Mail, Mine, Pen, dummyProfile} from '@shared/assets/images';
 
 interface ChatRoomInfoProps {
   roomName: string;
@@ -43,23 +43,31 @@ interface MemberItemProps {
 }
 
 // 모임 참여자 컴포넌트
-const MemberItem: React.FC<MemberItemProps> = ({member}) => (
-  <View style={styles.memberItem}>
-    <View style={styles.memberInfo}>
-      <Image
-        source={{uri: member.profileImage}}
-        resizeMode={'cover'}
-        style={styles.memberAvatar}
-      />
-      <Text variant="body2" weight="medium" color="#303030">
-        {member.name}
-      </Text>
+const MemberItem: React.FC<MemberItemProps> = ({member}) => {
+  // profileImage가 dummyProfile(로컬 이미지)인지 URL(문자열)인지 확인
+  const imageSource =
+    member.profileImage === dummyProfile
+      ? dummyProfile // 로컬 이미지
+      : {uri: member.profileImage}; // URL 이미지
+
+  return (
+    <View style={styles.memberItem}>
+      <View style={styles.memberInfo}>
+        <Image
+          source={imageSource}
+          resizeMode={'cover'}
+          style={styles.memberAvatar}
+        />
+        <Text variant="body2" weight="medium" color="#303030">
+          {member.name}
+        </Text>
+      </View>
+      <View style={styles.memberBadges}>
+        {member.isHost && <Mine style={styles.hostBadge} />}
+      </View>
     </View>
-    <View style={styles.memberBadges}>
-      {member.isHost && <Mine style={styles.hostBadge} />}
-    </View>
-  </View>
-);
+  );
+};
 
 const ChatRoomInfo: React.FC<ChatRoomInfoProps> = ({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/features/Chat/index.tsx
+++ b/src/features/Chat/index.tsx
@@ -57,6 +57,7 @@ const Chat: React.FC = () => {
               props.navigation.navigate('ChatRoom', {roomId});
             }}
             onDmChatRoomPress={dmRoomId => {
+              console.log('[Chat] DM 채팅방으로 네비게이션:', dmRoomId);
               props.navigation.navigate('ChatRoom', {dmChatRoomId: dmRoomId});
             }}
           />

--- a/src/features/Chat/lib/websocket.ts
+++ b/src/features/Chat/lib/websocket.ts
@@ -1,0 +1,224 @@
+import {Client, IMessage} from '@stomp/stompjs';
+import {config} from '@/shared/config/env';
+import {secureStorage} from '@/shared/lib/security';
+import {DmMessageResponse} from '../api/api';
+
+// React Native에서 WebSocket 사용을 위한 설정
+if (typeof global !== 'undefined') {
+  // @ts-ignore
+  global.WebSocket = global.WebSocket || require('ws');
+}
+
+// WebSocket 연결 상태 타입
+export type WebSocketStatus =
+  | 'disconnected'
+  | 'connecting'
+  | 'connected'
+  | 'error';
+
+// 메시지 콜백 타입
+export type MessageCallback = (message: DmMessageResponse) => void;
+
+// WebSocket 서비스 클래스
+class WebSocketService {
+  private client: Client | null = null;
+  private status: WebSocketStatus = 'disconnected';
+  private messageCallbacks: Map<number, MessageCallback[]> = new Map();
+  private subscriptions: Map<number, any> = new Map();
+
+  /**
+   * WebSocket URL 생성
+   */
+  private getWebSocketUrl(): string {
+    // HTTP URL을 WebSocket URL로 변환
+    const wsUrl = config.API_URL.replace('http://', 'ws://').replace(
+      'https://',
+      'wss://',
+    );
+    return `${wsUrl}/ws`;
+  }
+
+  /**
+   * WebSocket 연결
+   */
+  async connect(): Promise<void> {
+    if (this.status === 'connected' || this.status === 'connecting') {
+      return;
+    }
+
+    try {
+      this.status = 'connecting';
+
+      // JWT 토큰 가져오기
+      const token = await secureStorage.getToken();
+      if (!token) {
+        throw new Error('인증 토큰이 없습니다.');
+      }
+
+      const wsUrl = this.getWebSocketUrl();
+      console.log('[WebSocket] 연결 시도:', wsUrl);
+
+      // STOMP 클라이언트 생성
+      this.client = new Client({
+        brokerURL: wsUrl,
+        connectHeaders: {
+          Authorization: `Bearer ${token}`,
+        },
+        debug: str => {
+          console.log('[STOMP Debug]', str);
+        },
+        reconnectDelay: 5000,
+        heartbeatIncoming: 4000,
+        heartbeatOutgoing: 4000,
+      });
+
+      // 연결 성공 콜백
+      this.client.onConnect = () => {
+        console.log('[WebSocket] 연결됨');
+        this.status = 'connected';
+      };
+
+      // 연결 해제 콜백
+      this.client.onDisconnect = () => {
+        console.log('[WebSocket] 연결 해제됨');
+        this.status = 'disconnected';
+      };
+
+      // 에러 콜백
+      this.client.onStompError = frame => {
+        console.error('[WebSocket] STOMP 에러:', frame.headers['message']);
+        console.error('[WebSocket] 추가 정보:', frame.body);
+        this.status = 'error';
+      };
+
+      // WebSocket 에러 콜백
+      this.client.onWebSocketError = error => {
+        console.error('[WebSocket] WebSocket 에러:', error);
+        this.status = 'error';
+      };
+
+      // 연결 시작
+      this.client.activate();
+    } catch (error) {
+      console.error('[WebSocket] 연결 실패:', error);
+      this.status = 'error';
+      throw error;
+    }
+  }
+
+  /**
+   * WebSocket 연결 해제
+   */
+  disconnect(): void {
+    if (this.client) {
+      this.client.deactivate();
+      this.client = null;
+    }
+
+    this.status = 'disconnected';
+    this.messageCallbacks.clear();
+    this.subscriptions.clear();
+  }
+
+  /**
+   * 채팅방 구독
+   */
+  subscribeToChatRoom(dmChatRoomId: number, callback: MessageCallback): void {
+    if (!this.client || this.status !== 'connected') {
+      console.warn('[WebSocket] 연결되지 않음 - 구독 불가');
+      return;
+    }
+
+    // 콜백 등록
+    if (!this.messageCallbacks.has(dmChatRoomId)) {
+      this.messageCallbacks.set(dmChatRoomId, []);
+    }
+    this.messageCallbacks.get(dmChatRoomId)!.push(callback);
+
+    // 이미 구독 중인 경우 구독하지 않음
+    if (this.subscriptions.has(dmChatRoomId)) {
+      return;
+    }
+
+    // 채팅방 구독
+    const subscription = this.client.subscribe(
+      `/topic/dm/${dmChatRoomId}`,
+      (message: IMessage) => {
+        try {
+          const messageData: DmMessageResponse = JSON.parse(message.body);
+          this.handleNewMessage(dmChatRoomId, messageData);
+        } catch (error) {
+          console.error('[WebSocket] 메시지 파싱 에러:', error);
+        }
+      },
+    );
+
+    this.subscriptions.set(dmChatRoomId, subscription);
+    console.log(`[WebSocket] 채팅방 ${dmChatRoomId} 구독됨`);
+  }
+
+  /**
+   * 채팅방 구독 해제
+   */
+  unsubscribeFromChatRoom(dmChatRoomId: number): void {
+    // 콜백 제거
+    this.messageCallbacks.delete(dmChatRoomId);
+
+    // 구독 해제
+    const subscription = this.subscriptions.get(dmChatRoomId);
+    if (subscription) {
+      subscription.unsubscribe();
+      this.subscriptions.delete(dmChatRoomId);
+      console.log(`[WebSocket] 채팅방 ${dmChatRoomId} 구독 해제됨`);
+    }
+  }
+
+  /**
+   * 읽음 처리 메시지 전송
+   */
+  sendReadMessage(dmChatRoomId: number, receiverId: number): void {
+    if (!this.client || this.status !== 'connected') {
+      console.warn('[WebSocket] 연결되지 않음 - 읽음 처리 불가');
+      return;
+    }
+
+    this.client.publish({
+      destination: `/app/dm/${dmChatRoomId}/read-message`,
+      body: JSON.stringify({receiverId}),
+    });
+
+    console.log(
+      `[WebSocket] 읽음 처리 전송: 채팅방 ${dmChatRoomId}, 수신자 ${receiverId}`,
+    );
+  }
+
+  /**
+   * 새 메시지 처리
+   */
+  private handleNewMessage(
+    dmChatRoomId: number,
+    message: DmMessageResponse,
+  ): void {
+    const callbacks = this.messageCallbacks.get(dmChatRoomId);
+    if (callbacks) {
+      callbacks.forEach(callback => callback(message));
+    }
+  }
+
+  /**
+   * 현재 연결 상태 반환
+   */
+  getStatus(): WebSocketStatus {
+    return this.status;
+  }
+
+  /**
+   * 연결 상태 확인
+   */
+  isConnected(): boolean {
+    return this.status === 'connected';
+  }
+}
+
+// 싱글톤 인스턴스 생성
+export const webSocketService = new WebSocketService();

--- a/src/features/Chat/ui/ChatRoomListScreen/index.tsx
+++ b/src/features/Chat/ui/ChatRoomListScreen/index.tsx
@@ -125,8 +125,11 @@ const ChatRoomListScreen: React.FC<ChatRoomListScreenProps> = ({
 
   // DM 채팅방 클릭 핸들러
   const handleDmChatRoomPress = (dmRoomId: number) => {
+    console.log('[ChatRoomList] DM 채팅방 클릭됨:', dmRoomId);
     if (onDmChatRoomPress) {
       onDmChatRoomPress(dmRoomId);
+    } else {
+      console.warn('[ChatRoomList] onDmChatRoomPress 콜백이 없습니다.');
     }
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2366,6 +2366,11 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@stomp/stompjs@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.1.1.tgz"
+  integrity sha512-chcDs6YkAnKp1FqzwhGvh3i7v0+/ytzqWdKYw6XzINEKAzke/iD00dNgFPWSZEqktHOK+C1gSzXhLkLbARIaZw==
+
 "@svgr/babel-plugin-add-jsx-attribute@8.0.0":
   version "8.0.0"
   resolved "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz"
@@ -2594,6 +2599,13 @@
   version "10.0.0"
   resolved "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz"
   integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
+
+"@types/ws@^8.18.1":
+  version "8.18.1"
+  resolved "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -8546,6 +8558,11 @@ ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+
+ws@^8.18.2:
+  version "8.18.2"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz"
+  integrity sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION

## 📌 주요 변경 요약

이번 Pull Request는 앱의 브랜드 명 변경, 채팅 기능 강화, 새로운 API 및 의존성 추가를 중심으로 다양한 업데이트를 포함하고 있습니다. 다음은 카테고리별 핵심 변경 사항 요약입니다:

---

### 🏷️ 브랜드 업데이트:

* 앱의 표시 이름을 \*\*"GlueApp" → "Glue"\*\*로 변경 (`app.json`, `ios/GlueApp/Info2.plist` 반영).
* iOS 번들 식별자를 \*\*`com.sadajo.glue`\*\*로 변경 (`ios/GlueApp.xcodeproj/project.pbxproj`).

---

### 💬 채팅 기능 향상:

* `ChatListScreen`을 \*\*`ChatRoomListScreen`\*\*으로 대체하고, 그룹 및 DM(1:1) 채팅방 모두를 고려한 **네비게이션 로직 개선**.
* `src/features/Chat/api/api.ts`에 다음과 같은 DM 채팅방 관련 **세부 API 함수** 추가:

  * `getDmChatRoomDetail`
  * `getDmMessages`
  * `sendDmMessage`
* React Query 기반의 **새로운 DM 채팅용 훅(hooks)** 추가 (`src/features/Chat/api/hooks.ts`):

  * `useDmChatRoomDetail`
  * `useDmMessages`
  * `useSendDmMessage`

---

### 📦 의존성 업데이트:

* **웹소켓 기반 채팅 기능**을 위한 신규 의존성 추가 (`package.json`):

  * `@stomp/stompjs`
  * `ws`
  * `@types/ws`

---

### 🎨 UI 개선 사항:

* `ChatRoomInfo` 내 `MemberItem` 컴포넌트에서 **프로필 이미지 처리 개선**:

  * 로컬 이미지와 원격 URL 모두를 지원
  * 기본 이미지(`dummyProfile`) fallback 제공

---

### 🐛 디버깅 및 로깅:

* DM 채팅방으로의 네비게이션 추적을 위한 **console log 추가** (`src/features/Chat/index.tsx`).

---